### PR TITLE
Fix various typos and undefined variables related the no express-cookie middleware cookie case

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ var authS3O = function(req, res, next) {
 	if (req.cookies === undefined || req.cookies === null) {
 		var cookies = req.headers.cookie;
 	    if (cookies) {
-			req.cookies = cookie.parse(cookies, options);
+			req.cookies = cookieParser(cookies);
 	    } else {
 			req.cookies = Object.create(null);
 	    }


### PR DESCRIPTION
Without this express currently errors:

> `EXPRESS: Err: me so sad me no cookies`

cc @adambraimbridge @JakeChampion 

![screen shot 2015-09-28 at 12 09 05](https://cloud.githubusercontent.com/assets/825088/10133953/c2ab4f76-65d9-11e5-9ccd-668e222c379a.png)

Other useful resources on cookies:-
- https://next.ft.com/11bd3a2f-975a-3d90-b6cf-e2d81fde08ff
- https://www.youtube.com/watch?v=wGSzqqcl62c