### PR TITLE
Fix post-authentication redirections

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,13 +70,14 @@ var authS3O = function(req, res, next) {
 				if (authenticateToken(res, req.query.username, req.hostname, req.body.token)) {
 
 					// Strip the username and token from the URL (but keep any other parameters)
-					delete req.query['username'];
-					delete req.query['token'];
-					var cleanURL = url.parse(req.path);
-					cleanURL.query = req.query;
+					// Set 2nd parameter to true to parse the query string (so we can easily delete ?username=)
+					var cleanURL = url.parse(req.originalUrl, true);
+
+					// Node prefers ‘search’ over ‘query’ so remove ‘search’
+					delete cleanURL.search;
+					delete cleanURL.query.username;
 
 					debug("S3O: Parameters detected in URL and body. Redirecting to base path: " + url.format(cleanURL));
-					debug("S3O: " + JSON.stringify(req.path));
 
 					// Don't cache any redirection responses.
 					res.header("Cache-Control", "private, no-cache, no-store, must-revalidate");


### PR DESCRIPTION
This fixes a couple of issues.

`originalUrl` rather than `path` because if it's possible for `req.path` to *not* be equal to the path, e.g.

```js
var express = require('express');
var app = express();

var api = express.Router();
api.get('/test', (req, res) => {
   // req.path is ‘/test’ here!
});

app.use('/api', api);
```

Also fixes a bug where it wouldn't be able to remove the `username` query parameter properly.

Also also removes some code that was failing to remove the `token` query parameter, even though we don't pass that through as a query parameter anymore (it comes in the `POST` body).  Also it wasn't working.

Finally, removes some useless debug.