### PR TITLE
Avoid deprecation notices

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var url = require('url');
 var validate = require('./lib/validate');
 var cookieParser = require('cookie').parse;
 var s3oPublicKey = require('./lib/publickey');
-var urlencoded = require('body-parser').urlencoded();
+var urlencoded = require('body-parser').urlencoded({extended: true});
 
 // Authenticate token and save/delete cookies as appropriate.
 var authenticateToken = function (res, username, hostname, token) {


### PR DESCRIPTION
Need to explicitly set `extended` for `urlencoded()` since the default value is going to change in the next major version of `body-parser`.

See http://stackoverflow.com/questions/25471856/express-throws-error-as-body-parser-deprecated-undefined-extended