### PR TITLE
Add customisable cookie TTL. Fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This middleware can parse standard cookies via the [cookie](http://npmjs.com/pac
 # Finding the username of the logged in user
 The username is added to the 's3o_username' property of the res.locals object for all authenticated requests.
 
+# Setting the ttl of the cookie for an authenticated request
+Defaults to fifteen minutes. Use Express' `app.set` function before sending users to authenticate:
+`app.set('s3o-cookie-ttl', 86400000); // one day (in ms)`
+
 ## Usage example for Express
 If many routes require auth:
 ```js

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var authenticateToken = function (res, username, hostname, token) {
 		// Add username to res.locals, so apps can utilise it.
 		res.locals.s3o_username = username;
 		var cookieOptions = {
-			maxAge: 900000,
+			maxAge: res.app.get('s3o-cookie-ttl') || 900000,
 			httpOnly: true
 		};
 		res.cookie('s3o_username', username, cookieOptions);


### PR DESCRIPTION
Fixes our use-case where the fifteen-minute TTL is too short for a single-page app that rarely talks to the server. Nice future enhancement might be to add an option for session cookies.