### PR TITLE
Alternative middleware function for when redirection is undesirable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ app.post('/', authS3O);
 If you don't want the automatic redirect to the S3O login page, use the
 `authS3ONoRedirect` middleware. This could be because you want to protect an
 API endpoint for authenticated AJAX requests, for example. If the
-cookies are not present or are invalid, the `authS3ONoRedirect` 
+cookies are not present or are invalid, the `authS3ONoRedirect`
 middleware will respond with a simple `403: Forbidden` response:
 
 ```js
@@ -54,5 +54,5 @@ var app = express();
 var router = express.Router();
 var authS3ONoRedirect = require('s3o-middleware').authS3ONoRedirect;
 
-app.get('/some-athenticated-api', authS3ONoRedirect, router);
+app.get('/some-authenticated-api', authS3ONoRedirect, router);
 ```

--- a/README.md
+++ b/README.md
@@ -41,3 +41,18 @@ var authS3O = require('s3o-middleware');
 app.get('/', authS3O, router);
 app.post('/', authS3O);
 ```
+
+If you don't want the automatic redirect to the S3O login page, use the
+`authS3ONoRedirect` middleware. This could be because you want to protect an
+API endpoint for authenticated AJAX requests, for example. If the
+cookies are not present or are invalid, the `authS3ONoRedirect` 
+middleware will respond with a simple `403: Forbidden` response:
+
+```js
+var express = require('express');
+var app = express();
+var router = express.Router();
+var authS3ONoRedirect = require('s3o-middleware').authS3ONoRedirect;
+
+app.get('/some-athenticated-api', authS3ONoRedirect, router);
+```

--- a/index.js
+++ b/index.js
@@ -40,9 +40,7 @@ var authenticateToken = function (res, username, hostname, token) {
 	return false;
 };
 
-var authS3O = function (req, res, next) {
-	debug('S3O: Start.');
-
+var normaliseRequestCookies = function(req) {
 	if (req.cookies === undefined || req.cookies === null) {
 		var cookies = req.headers.cookie;
 		if (cookies) {
@@ -51,6 +49,12 @@ var authS3O = function (req, res, next) {
 			req.cookies = Object.create(null);
 		}
 	}
+}
+
+var authS3O = function (req, res, next) {
+	debug('S3O: Start.');
+
+	normaliseRequestCookies(req);
 
 	// Check for s3o username/token URL parameters.
 	// These parameters come from https://s3o.ft.com. It redirects back after it does the google authentication.
@@ -110,14 +114,7 @@ var authS3O = function (req, res, next) {
 var authS3ONoRedirect = function (req, res, next) {
 	debug('S3O: Start.');
 
-	if (req.cookies === undefined || req.cookies === null) {
-		var cookies = req.headers.cookie;
-		if (cookies) {
-			req.cookies = cookieParser(cookies);
-		} else {
-			req.cookies = Object.create(null);
-		}
-	}
+	normaliseRequestCookies(req);
 
 	if (req.cookies.s3o_username && req.cookies.s3o_token && authenticateToken(res, req.cookies.s3o_username, req.hostname, req.cookies.s3o_token)) {
 		debug('S3O: Authentication succeeded');


### PR DESCRIPTION
Our use case: putting S3O in front of AJAX API requests.

1) We need to be able to know in the front-end if authentication has failed
2) We don't want the redirection to S3O sign in to happen for AJAX requests

Usage:
```
import {authS3ONoRedirect} from 's3o-middleware';
// ...
router.use(authS3ONoRedirect);
// Users without valid cookie will get 403: Forbidden, otherwise next();
```

Thoughts/comments?