### PR TITLE
➕ Adds basic .eslintrc via next-front-page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,38 @@
+const config = {
+	'env': {
+		'browser': true,
+		'es6': true,
+		'mocha': true,
+		'node': true
+	},
+	'parserOptions': {
+		'sourceType': 'module'
+	},
+	'rules': {
+		'eqeqeq': 2,
+		'guard-for-in': 2,
+		'new-cap': 2,
+		'no-caller': 2,
+		'no-console': 2,
+		'no-extend-native': 2,
+		'no-irregular-whitespace': 2,
+		'no-loop-func': 2,
+		'no-multi-spaces': 2,
+		'no-undef': 2,
+		'no-underscore-dangle': 0,
+		'no-unused-vars': 2,
+		'no-var': 2,
+		'one-var': [2, 'never'],
+		'quotes': [2, 'single'],
+		'space-before-function-paren': [2, 'always'],
+		'wrap-iife': 2
+	},
+	'globals': {
+		'fetch': true,
+		'requireText': true
+	},
+	'plugins': [],
+	'extends': []
+};
+
+module.exports = config;

--- a/index.js
+++ b/index.js
@@ -3,29 +3,29 @@
 //  — It's intended to change sporadically and without warning, mainly for security testing.
 //  — Currently it comes in DER format and needs to be converted to PEM format
 
-var debug = require('debug')('middleware:auth:s3o');
-var url = require('url');
-var cookieParser = require('cookie').parse;
-var s3oPublicKey = require('./lib/publickey')(debug);
-var validate = require('./lib/validate')(s3oPublicKey);
-var urlencoded = require('body-parser').urlencoded({extended: true});
+let debug = require('debug')('middleware:auth:s3o');
+let url = require('url');
+let cookieParser = require('cookie').parse;
+let s3oPublicKey = require('./lib/publickey')(debug);
+let validate = require('./lib/validate')(s3oPublicKey);
+let urlencoded = require('body-parser').urlencoded({extended: true});
 
 // Authenticate token and save/delete cookies as appropriate.
-var authenticateToken = function (res, username, hostname, token) {
-	var publicKey = s3oPublicKey();
+let authenticateToken = function (res, username, hostname, token) {
+	let publicKey = s3oPublicKey();
 	if (!publicKey) {
 		res.status(500).send('Has not yet downloaded public key from S3O');
 		return false;
 	}
-	var key = username + '-' + hostname;
-	var result = validate(key, token);
+	let key = username + '-' + hostname;
+	let result = validate(key, token);
 
 	if (result) {
 		debug('S3O: Authentication successful: ' + username);
 
 		// Add username to res.locals, so apps can utilise it.
 		res.locals.s3o_username = username;
-		var cookieOptions = {
+		let cookieOptions = {
 			maxAge: res.app.get('s3o-cookie-ttl') || 900000,
 			httpOnly: true
 		};
@@ -40,9 +40,9 @@ var authenticateToken = function (res, username, hostname, token) {
 	return false;
 };
 
-var normaliseRequestCookies = function(req) {
+let normaliseRequestCookies = function (req) {
 	if (req.cookies === undefined || req.cookies === null) {
-		var cookies = req.headers.cookie;
+		let cookies = req.headers.cookie;
 		if (cookies) {
 			req.cookies = cookieParser(cookies);
 		} else {
@@ -51,7 +51,7 @@ var normaliseRequestCookies = function(req) {
 	}
 }
 
-var authS3O = function (req, res, next) {
+let authS3O = function (req, res, next) {
 	debug('S3O: Start.');
 
 	normaliseRequestCookies(req);
@@ -66,7 +66,7 @@ var authS3O = function (req, res, next) {
 
 					// Strip the username and token from the URL (but keep any other parameters)
 					// Set 2nd parameter to true to parse the query string (so we can easily delete ?username=)
-					var cleanURL = url.parse(req.originalUrl, true);
+					let cleanURL = url.parse(req.originalUrl, true);
 
 					// Node prefers ‘search’ over ‘query’ so remove ‘search’
 					delete cleanURL.search;
@@ -96,8 +96,8 @@ var authS3O = function (req, res, next) {
 
 	// Send the user to s3o to authenticate
 	} else {
-		var protocol = (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] === 'https') ? 'https' : req.protocol;
-		var s3o_url = 'https://s3o.ft.com/v2/authenticate?post=true&host=' + encodeURIComponent(req.hostname) + '&redirect=' + encodeURIComponent(protocol + '://' + req.headers.host + req.originalUrl);
+		let protocol = (req.headers['x-forwarded-proto'] && req.headers['x-forwarded-proto'] === 'https') ? 'https' : req.protocol;
+		let s3o_url = 'https://s3o.ft.com/v2/authenticate?post=true&host=' + encodeURIComponent(req.hostname) + '&redirect=' + encodeURIComponent(protocol + '://' + req.headers.host + req.originalUrl);
 		debug('S3O: No token/s3o_username found. Redirecting to ' + s3o_url);
 
 		// Don't cache any redirection responses.
@@ -111,7 +111,7 @@ var authS3O = function (req, res, next) {
 // Alternative authentication middleware which does not redirect to S3O when
 // cookies are missing or invalid. This can be used in front of API calls
 // where a redirect will be undesirable
-var authS3ONoRedirect = function (req, res, next) {
+let authS3ONoRedirect = function (req, res, next) {
 	debug('S3O: Start.');
 
 	normaliseRequestCookies(req);
@@ -134,4 +134,4 @@ module.exports = authS3O;
 module.exports.authS3ONoRedirect = authS3ONoRedirect;
 module.exports.validate = validate;
 module.exports.ready = s3oPublicKey({ promise: true })
-	.then(function() { return true; });
+	.then(function () { return true; });

--- a/lib/publickey.js
+++ b/lib/publickey.js
@@ -1,26 +1,26 @@
 'use strict';
 
-var Poller = require('ft-poller');
-var S3O_PUBLIC_KEY_URL = 'https://s3o.ft.com/publickey';
+let Poller = require('ft-poller');
+let S3O_PUBLIC_KEY_URL = 'https://s3o.ft.com/publickey';
 
-module.exports = function(debug) {
-	var publicKey;
+module.exports = function (debug) {
+	let publicKey;
 
-	var flagsPoller = new Poller({
+	let flagsPoller = new Poller({
 		url: S3O_PUBLIC_KEY_URL,
 		retry: 3,
 		refreshInterval: 1000 * 60 * 5,
-		parseData: function(data) {
-			debug("event=S3O_PUBLIC_KEY_LOADED source=" + S3O_PUBLIC_KEY_URL);
+		parseData: function (data) {
+			debug('event=S3O_PUBLIC_KEY_LOADED source=' + S3O_PUBLIC_KEY_URL);
 			publicKey = data;
 		}
 	});
 
-	var promise = flagsPoller.start({ initialRequest: true });
+	let promise = flagsPoller.start({ initialRequest: true });
 
-	return function(opts) {
+	return function (opts) {
 		if (opts && opts.promise) {
-			return promise.then(function() { return publicKey; });
+			return promise.then(function () { return publicKey; });
 		}
 		return publicKey;
 	};

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,23 +1,23 @@
 'use strict';
 
-var crypto = require('crypto');
-var NodeRSA = require('node-rsa');
+let crypto = require('crypto');
+let NodeRSA = require('node-rsa');
 
 module.exports = function (s3oPublicKey) {
-	return function(key, token) {
-		var publicKey = s3oPublicKey();
+	return function (key, token) {
+		let publicKey = s3oPublicKey();
 		if (!publicKey) {
 			return false;
 		}
 
 		// Convert the publicKey from DER format to PEM format
 		// See: https://www.npmjs.com/package/node-rsa
-		var buffer = new Buffer(publicKey, 'base64');
-		var derKey = new NodeRSA(buffer, 'pkcs8-public-der');
-		var publicPem = derKey.exportKey('pkcs8-public-pem');
+		let buffer = new Buffer(publicKey, 'base64');
+		let derKey = new NodeRSA(buffer, 'pkcs8-public-der');
+		let publicPem = derKey.exportKey('pkcs8-public-pem');
 
 		// See: https://nodejs.org/api/crypto.html
-		var verifier = crypto.createVerify('sha1');
+		let verifier = crypto.createVerify('sha1');
 		verifier.update(key);
 		return verifier.verify(publicPem, token, 'base64');
 	};

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "debug": "^2.2.0",
     "ft-poller": "^2.1.0",
     "node-rsa": "^0.2.25"
+  },
+  "devDependencies": {
+    "eslint": "^3.10.2"
   }
 }


### PR DESCRIPTION
This adds a basic `.eslintrc.js` via [next-front-page](https://github.com/Financial-Times/next-front-page/blob/master/.eslintrc.json) — all I've done is remove the bits with regards to React.

I've also run `--fix` on all the JS in the repo so it complies. Biggest changes:

- Convert `var` to `const` or `let`
- Spacing

Merging this probably isn't necessary for my next PR to proceed, which adds tests for Express (See #29). I'll want to get that merged in before submitting my later PR for Koa support, as doing so ensures I don't break anything in the meantime.