### PR TITLE
🐛 Fixes issue with noRedirect auth failing

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ let authS3ONoRedirect = function (req, res, next) {
 
 	normaliseRequestCookies(req);
 
-	if (req.cookies.s3o_username && req.cookies.s3o_token && authenticateToken(res, req.cookies.s3o_username, req.hostname, req.cookies.s3o_token)) {
+	if (req.cookies.s3o_username && req.cookies.s3o_token && authenticateToken(req.cookies.s3o_username, req.hostname, req.cookies.s3o_token)) {
 		debug('S3O: Authentication succeeded');
 		return next();
 	};

--- a/test/s3o-middleware.spec.js
+++ b/test/s3o-middleware.spec.js
@@ -19,150 +19,150 @@ const nextStub = sinon.stub();
 nextStub.returns('next returned');
 
 describe('s3o-middleware', () => {
-  let reqFixture;
-  let resFixture;
-  let s3o;
+	let reqFixture;
+	let resFixture;
+	let s3o;
 
-  beforeEach(() => {
-    validatorStub.reset();
-    nextStub.reset();
+	beforeEach(() => {
+		validatorStub.reset();
+		nextStub.reset();
 
-    // Reset overridden fixtures
-    reqFixture = {
-      cookies: {
-        s3o_username: 'test',
-        s3o_token: 'test-test-123',
-      },
-      hostname: 'localhost',
-      headers: {
-        'transfer-encoding': 'utf8'
-      }
-    };
+		// Reset overridden fixtures
+		reqFixture = {
+			cookies: {
+				s3o_username: 'test',
+				s3o_token: 'test-test-123',
+			},
+			hostname: 'localhost',
+			headers: {
+				'transfer-encoding': 'utf8'
+			}
+		};
 
-    resFixture = {
-      clearCookie: sinon.spy(),
-      status: sinon.spy(),
-      send: sinon.spy(),
-      header: sinon.spy(),
-      locals: {},
-      app: {
-        get: () => 9999,
-      },
-      cookie: sinon.spy(),
-      redirect: sinon.stub(),
-    };
+		resFixture = {
+			clearCookie: sinon.spy(),
+			status: sinon.spy(),
+			send: sinon.spy(),
+			header: sinon.spy(),
+			locals: {},
+			app: {
+				get: () => 9999,
+			},
+			cookie: sinon.spy(),
+			redirect: sinon.stub(),
+		};
 
-    s3o = proxyquire('../', {
-      '@financial-times/s3o-middleware-utils/authenticate': {
-        authenticateToken: validatorStub,
-      },
-    });
-  });
+		s3o = proxyquire('../', {
+			'@financial-times/s3o-middleware-utils/authenticate': {
+				authenticateToken: validatorStub,
+			},
+		});
+	});
 
-  describe('normal authentication', () => {
-    describe('when user POSTs a username', () => {
-      it('redirects if user authenticates', () => {
-        validatorStub.returns(true);
-        reqFixture.method = 'POST';
-        reqFixture.query = {
-          username: 'test',
-        };
-        reqFixture.body = {
-          token: 'abc123',
-        };
-        reqFixture.originalUrl = 'http://localhost';
+	describe('normal authentication', () => {
+		describe('when user POSTs a username', () => {
+			it('redirects if user authenticates', () => {
+				validatorStub.returns(true);
+				reqFixture.method = 'POST';
+				reqFixture.query = {
+					username: 'test',
+				};
+				reqFixture.body = {
+					token: 'abc123',
+				};
+				reqFixture.originalUrl = 'http://localhost';
 
-        s3o(reqFixture, resFixture, nextStub);
+				s3o(reqFixture, resFixture, nextStub);
 
-        validatorStub.withArgs('test', 'localhost', 'abc123').should.have.been.calledOnce;
-        resFixture.header.withArgs('Cache-Control', 'private, no-cache, no-store, must-revalidate')
-          .should.have.been.calledOnce;
-        resFixture.header.withArgs('Pragma', 'no-cache').should.have.been.calledOnce;
-        resFixture.header.withArgs('Expires', 0).should.have.been.calledOnce;
-        resFixture.redirect.withArgs('http://localhost/').should.have.been.calledOnce;
-      });
+				validatorStub.withArgs('test', 'localhost', 'abc123').should.have.been.calledOnce;
+				resFixture.header.withArgs('Cache-Control', 'private, no-cache, no-store, must-revalidate')
+					.should.have.been.calledOnce;
+				resFixture.header.withArgs('Pragma', 'no-cache').should.have.been.calledOnce;
+				resFixture.header.withArgs('Expires', 0).should.have.been.calledOnce;
+				resFixture.redirect.withArgs('http://localhost/').should.have.been.calledOnce;
+			});
 
-      it('responds with error message if authentication fails', () => {
-        validatorStub.returns(false);
+			it('responds with error message if authentication fails', () => {
+				validatorStub.returns(false);
 
-        s3o(reqFixture, resFixture, nextStub);
+				s3o(reqFixture, resFixture, nextStub);
 
-        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
-        resFixture.send
-          .withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
-          .should.have.been.calledOnce;
-      });
-    });
+				validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
+				resFixture.send
+					.withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
+					.should.have.been.calledOnce;
+			});
+		});
 
-    describe('when user has cookies', () => {
-      it('calls next() after authenticating cookies', () => {
-        reqFixture.method = 'GET';
-        validatorStub.returns(true);
+		describe('when user has cookies', () => {
+			it('calls next() after authenticating cookies', () => {
+				reqFixture.method = 'GET';
+				validatorStub.returns(true);
 
-        s3o(reqFixture, resFixture, nextStub);
+				s3o(reqFixture, resFixture, nextStub);
 
-        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
-        nextStub.should.have.been.calledOnce;
-      });
+				validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
+				nextStub.should.have.been.calledOnce;
+			});
 
-      it('responds with error message if authentication fails', () => {
-        reqFixture.method = 'GET';
-        validatorStub.returns(false);
+			it('responds with error message if authentication fails', () => {
+				reqFixture.method = 'GET';
+				validatorStub.returns(false);
 
-        s3o(reqFixture, resFixture, nextStub);
+				s3o(reqFixture, resFixture, nextStub);
 
-        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
-        nextStub.should.not.have.been.called;
-        resFixture.send.withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
-          .should.have.been.calledOnce;
-      });
-    });
+				validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
+				nextStub.should.not.have.been.called;
+				resFixture.send.withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
+					.should.have.been.calledOnce;
+			});
+		});
 
-    describe('when user is unauthenticated', () => {
-      it('redirects to s3o login URL', () => {
-        delete reqFixture.cookies;
-        delete reqFixture.query;
-        delete reqFixture.method;
-        reqFixture.headers.host = 'localhost';
-        reqFixture.originalUrl = 'http://localhost';
-        reqFixture.protocol = 'https';
-        resFixture.redirect.returns('redirect returned');
+		describe('when user is unauthenticated', () => {
+			it('redirects to s3o login URL', () => {
+				delete reqFixture.cookies;
+				delete reqFixture.query;
+				delete reqFixture.method;
+				reqFixture.headers.host = 'localhost';
+				reqFixture.originalUrl = 'http://localhost';
+				reqFixture.protocol = 'https';
+				resFixture.redirect.returns('redirect returned');
 
-        const result = s3o(reqFixture, resFixture, nextStub);
+				const result = s3o(reqFixture, resFixture, nextStub);
 
-        resFixture.header.withArgs('Cache-Control', 'private, no-cache, no-store, must-revalidate')
-          .should.have.been.calledOnce;
-        resFixture.header.withArgs('Pragma', 'no-cache').should.have.been.calledOnce;
-        resFixture.header.withArgs('Expires', 0).should.have.been.calledOnce;
-        resFixture.redirect.withArgs('https://s3o.ft.com/v2/authenticate?post=true&host=localhost&redirect=https%3A%2F%2Flocalhosthttp%3A%2F%2Flocalhost')
-          .should.have.been.calledOnce;
-        result.should.equal('redirect returned');
-      });
-    });
-  });
+				resFixture.header.withArgs('Cache-Control', 'private, no-cache, no-store, must-revalidate')
+					.should.have.been.calledOnce;
+				resFixture.header.withArgs('Pragma', 'no-cache').should.have.been.calledOnce;
+				resFixture.header.withArgs('Expires', 0).should.have.been.calledOnce;
+				resFixture.redirect.withArgs('https://s3o.ft.com/v2/authenticate?post=true&host=localhost&redirect=https%3A%2F%2Flocalhosthttp%3A%2F%2Flocalhost')
+					.should.have.been.calledOnce;
+				result.should.equal('redirect returned');
+			});
+		});
+	});
 
-  describe('no redirect authentication', () => {
-    it('calls next() on successful authentication', () => {
-      validatorStub.returns(true);
+	describe('no redirect authentication', () => {
+		it('calls next() on successful authentication', () => {
+			validatorStub.returns(true);
 
-      const result = s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
+			const result = s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
 
-      validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
-      nextStub.should.have.been.calledOnce;
-      result.should.equal('next returned');
-    });
+			validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
+			nextStub.should.have.been.calledOnce;
+			result.should.equal('next returned');
+		});
 
-    it('returns 403 on authentication failure', () => {
-      validatorStub.returns(false);
+		it('returns 403 on authentication failure', () => {
+			validatorStub.returns(false);
 
-      s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
+			s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
 
-      validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
-      nextStub.should.not.have.been.called;
-      resFixture.clearCookie.withArgs('s3o_username').should.have.been.calledOnce;
-      resFixture.clearCookie.withArgs('s3o_token').should.have.been.calledOnce;
-      resFixture.status.withArgs(403).should.have.been.calledOnce;
-      resFixture.send.withArgs('Forbidden').should.have.been.calledOnce;
-    });
-  });
+			validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
+			nextStub.should.not.have.been.called;
+			resFixture.clearCookie.withArgs('s3o_username').should.have.been.calledOnce;
+			resFixture.clearCookie.withArgs('s3o_token').should.have.been.calledOnce;
+			resFixture.status.withArgs(403).should.have.been.calledOnce;
+			resFixture.send.withArgs('Forbidden').should.have.been.calledOnce;
+		});
+	});
 });

--- a/test/s3o-middleware.spec.js
+++ b/test/s3o-middleware.spec.js
@@ -54,8 +54,8 @@ describe('s3o-middleware', () => {
 
     s3o = proxyquire('../', {
       '@financial-times/s3o-middleware-utils/authenticate': {
-				authenticateToken: validatorStub,
-			},
+        authenticateToken: validatorStub,
+      },
     });
   });
 
@@ -74,6 +74,7 @@ describe('s3o-middleware', () => {
 
         s3o(reqFixture, resFixture, nextStub);
 
+        validatorStub.withArgs('test', 'localhost', 'abc123').should.have.been.calledOnce;
         resFixture.header.withArgs('Cache-Control', 'private, no-cache, no-store, must-revalidate')
           .should.have.been.calledOnce;
         resFixture.header.withArgs('Pragma', 'no-cache').should.have.been.calledOnce;
@@ -86,6 +87,7 @@ describe('s3o-middleware', () => {
 
         s3o(reqFixture, resFixture, nextStub);
 
+        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
         resFixture.send
           .withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
           .should.have.been.calledOnce;
@@ -98,6 +100,8 @@ describe('s3o-middleware', () => {
         validatorStub.returns(true);
 
         s3o(reqFixture, resFixture, nextStub);
+
+        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
         nextStub.should.have.been.calledOnce;
       });
 
@@ -106,6 +110,8 @@ describe('s3o-middleware', () => {
         validatorStub.returns(false);
 
         s3o(reqFixture, resFixture, nextStub);
+
+        validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
         nextStub.should.not.have.been.called;
         resFixture.send.withArgs('<h1>Authentication error.</h1><p>For access, please log in with your FT account</p>')
           .should.have.been.calledOnce;
@@ -141,6 +147,7 @@ describe('s3o-middleware', () => {
 
       const result = s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
 
+      validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
       nextStub.should.have.been.calledOnce;
       result.should.equal('next returned');
     });
@@ -150,6 +157,7 @@ describe('s3o-middleware', () => {
 
       s3o.authS3ONoRedirect(reqFixture, resFixture, nextStub);
 
+      validatorStub.withArgs('test', 'localhost', 'test-test-123').should.have.been.calledOnce;
       nextStub.should.not.have.been.called;
       resFixture.clearCookie.withArgs('s3o_username').should.have.been.calledOnce;
       resFixture.clearCookie.withArgs('s3o_token').should.have.been.calledOnce;


### PR DESCRIPTION
Tests didn't catch this because `authenticateToken` is stubbed out. I've added a few assertions to ensure it's being called with the expected arguments.