### PR TITLE
Correct documentation on how to get the username

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Middleware to handle authenticating with [S3O](http://s3o.ft.com/docs)
 This middleware can parse standard cookies via the [cookie](http://npmjs.com/package/cookie) package. If wanting to use signed cookies or json cookies, please use the [cookie-parser](https://www.npmjs.com/package/cookie-parser) middleware before using the S3O middleware.
 
 # Finding the username of the logged in user
-The username is added to the 's3o_username' property of the res.locals object for all authenticated requests.
+The username can be found in the request cookie, under `req.cookies.s3o_username`.
 
 # Setting the ttl of the cookie for an authenticated request
 Defaults to fifteen minutes. Use Express' `app.set` function before sending users to authenticate:


### PR DESCRIPTION
`res.locals.s3o_username` is just never set, maybe the code
was updated and the documentation was missed 🤷‍♂️ 